### PR TITLE
Make {parallelly} version controllable by matrix strategy

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 name: R-CMD-check
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -75,18 +75,21 @@ jobs:
         run: |
           install.packages(".", repos = NULL, type = "source")  ## needed by parallel workers
           lapply(c("future.batchtools", "future.callr"), FUN = function(pkg) if (grepl(pkg, "${{ matrix.config.future_plan }}")) install.packages(pkg))
-          remotes::install_github("futureverse/parallelly", ref="develop")
         shell: Rscript {0}
 
       - name: Test with specific future version?
         run: |
           globals_version <- Sys.getenv("R_GLOBALS_VERSION")
           if (nzchar(globals_version)) {
-            remotes::install_github("futureverse/globals", ref=globals_version)
+            remotes::install_github("futureverse/globals", ref=globals_version, upgrade = FALSE)
+          }
+          parallelly_version <- Sys.getenv("R_PARALLELLY_VERSION")
+          if (nzchar(parallelly_version)) {
+            remotes::install_github("futureverse/parallelly", ref=parallelly_version, upgrade = FALSE)
           }
           future_version <- Sys.getenv("R_FUTURE_VERSION")
           if (nzchar(future_version)) {
-            remotes::install_github("futureverse/future", ref=future_version)
+            remotes::install_github("futureverse/future", ref=future_version, upgrade = FALSE)
           }
         shell: Rscript {0}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,6 +20,7 @@ jobs:
           - {os: windows-latest, r: 'release'  }
           - {os: windows-latest, r: 'oldrel'   }
 #          - {os: macOS-latest,   r: 'devel'    }
+          - {os: macOS-latest,   r: 'release', parallelly_version: 9572cd0, label: 'w/ compatible parallelly' }
           - {os: macOS-latest,   r: 'release'  }
           - {os: macOS-latest,   r: 'oldrel'   }
 #          - {os: ubuntu-latest,  r: 'devel'    }


### PR DESCRIPTION
To facilitate troubleshooting the compatibility between {doFuture} and {parallelly} (https://github.com/futureverse/doFuture/issues/87), I updated the code from https://github.com/futureverse/doFuture/commit/ccb547d978065aa40b0280dbe75880cbbb5d7598 to make the version of {parallelly} installed controllable in the matrix strategy, exactly as was already done for {future} and {globals}.

In addition, I did the following:

* Added `upgrade = FALSE` to all the `remotes::install_github()` calls. Otherwise there is the risk that a more recent version, eg of {globals}, is installed when installing another package
* Added a manual trigger to the `R CMD check` workflow
* Added a passing macOS build that installs {parallelly} from https://github.com/futureverse/parallelly/commit/9572cd0ce74fa5aac7103e0a6310140feacd00d8